### PR TITLE
Fe/api key connection validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Bun
+bun.lockb
+bun.lock

--- a/src/lib/apis/openrouter.ts
+++ b/src/lib/apis/openrouter.ts
@@ -25,6 +25,18 @@ export interface ChatCompletionResponse {
   // Add other fields if necessary, like 'id', 'model', 'usage', etc.
 }
 
+export interface Model {
+  id: string;
+  name: string;
+  description: string;
+  context_length: number;
+  // Add other relevant fields from the OpenRouter /models endpoint
+}
+
+export interface ModelsResponse {
+  data: Model[];
+}
+
 async function getApiKey(): Promise<string> {
   const apiKey = await settingsStorage.getSetting<string>(API_KEY_STORAGE_KEY);
   if (!apiKey) {
@@ -46,7 +58,7 @@ export function extractHtmlContent(content: string): string {
   return result.trim();
 }
 
-async function callOpenRouterApi(
+export async function callOpenRouterApi(
   messages: ChatMessage[],
   model: string = "qwen/qwen3-32b", // Default model
 ): Promise<string> {
@@ -128,4 +140,48 @@ export async function refinePage(
   ];
   const rawContent = await callOpenRouterApi(messages);
   return extractHtmlContent(rawContent);
+}
+
+export async function checkConnectionAndListModels(apiKeyOverride?: string): Promise<Model[]> {
+  const apiKey = apiKeyOverride || await getApiKey();
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+
+  try {
+    // Attempt to filter by provider directly in the API call
+    const response = await fetch("https://openrouter.ai/api/v1/models?provider=anthropic", {
+      method: "GET",
+      headers
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error("OpenRouter API error response (models):", errorBody);
+      let errorMessage = `HTTP error! status: ${response.status}`;
+      try {
+        const parsedError = JSON.parse(errorBody);
+        if (parsedError.error && parsedError.error.message) {
+          errorMessage += `, message: ${parsedError.error.message}`;
+        } else {
+          errorMessage += `, message: ${errorBody}`;
+        }
+      } catch (e) {
+        errorMessage += `, message: ${errorBody}`;
+      }
+      throw new Error(errorMessage);
+    }
+
+    const data: ModelsResponse = await response.json();
+    
+    if (data.data && Array.isArray(data.data)) {
+      return data.data;
+    } else {
+      throw new Error("No model data in OpenRouter API response or unexpected format");
+    }
+  } catch (error) {
+    console.error("Error fetching models from OpenRouter API:", error);
+    throw error; // Re-throw to be handled by the caller
+  }
 }

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -286,7 +286,7 @@
 				};
 
 				const body = {
-					model: "meta-llama/llama-3.1-8b-instruct",
+					model: "qwen/qwen3-32b",
 					messages: [{ role: "user", content: "Hello" }],
 				};
 


### PR DESCRIPTION
**Changes:**
- Add connection test with `qwen/qwen3-32b` model
- Implement eye icon for API key show/hide
- Export callOpenRouterApi for component reuse
- Fix issue in the First page (`ask-for-api-key`)
- Add Check connection  in the `ask-for-api-key` page

**ScreenShots:**

![Check Connection button in the settings page](https://github.com/user-attachments/assets/385db557-bab9-4865-91f9-d0313d1d9873)
![Check API token](https://github.com/user-attachments/assets/692e8b7a-ed0a-48f5-b849-d266dc9adce7)
![Check connection  in the `ask-for-api-key` page](https://github.com/user-attachments/assets/58ec061b-6bc2-44b2-8f46-cfe1ee8cf630)
